### PR TITLE
Adequacao do arquivo XML de layout do frontend

### DIFF
--- a/app/design/frontend/base/default/layout/mariosam_customerlawprotection.xml
+++ b/app/design/frontend/base/default/layout/mariosam_customerlawprotection.xml
@@ -21,7 +21,7 @@
         </reference>
         <!-- Call the phtml with popup LGPD in all pages :: ifconfig="customerlawprotection/frontend_message/enabled" condition="1" -->
         <reference name="after_body_start">
-            <block type="customerlawprotection/customerlawprotectionblock" name="consent.popup" as="consent_popup" template="mariosam/customerlawprotection/consentpopup.phtml" ifconfig="customerlawprotection/frontend_message/enabled"/>
+            <block type="customerlawprotection/customerLawProtectionBlock" name="consent.popup" as="consent_popup" template="mariosam/customerlawprotection/consentpopup.phtml" ifconfig="customerlawprotection/frontend_message/enabled"/>
         </reference>
     </default>
 </layout>


### PR DESCRIPTION
Nos meus testes rodando em máquinas e containers Dockers no Linux, a referência do bloco não funcionou e uma exceção de bloco não existente era descrita nos logs. Alterando o nome do bloco referenciado no XML de layout respeitando o case sensitive para ficar no mesmo formato do nome da classe, passou a funcionar normalmente.